### PR TITLE
fix/feat: preserve backend config and add backend selection prompt

### DIFF
--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,7 +1,22 @@
 import { Command } from "commander";
 import { resolve, join } from "path";
 import { writeFile } from "fs/promises";
+import { createInterface } from "readline";
 import { scanProject, printScanSummary } from "../scanner/project";
+import { loadConfig } from "../config";
+
+async function promptBackend(): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(
+      "\n  Select a backend:\n    1) 1Password (default)\n    2) Bitwarden\n  Choice [1]: ",
+      (answer) => {
+        rl.close();
+        resolve(answer.trim());
+      }
+    );
+  });
+}
 
 export const scanCommand = new Command("scan")
   .description("Scan project and generate shipkey.json")
@@ -15,6 +30,22 @@ export const scanCommand = new Command("scan")
     printScanSummary(result);
 
     if (!opts.dryRun) {
+      // Preserve backend from existing config, or prompt if not yet set
+      let backend: string | undefined;
+      try {
+        const existing = await loadConfig(projectRoot);
+        backend = existing.backend;
+      } catch {
+        // No existing config
+      }
+
+      if (!backend) {
+        const choice = await promptBackend();
+        backend = choice === "2" ? "bitwarden" : "1password";
+      }
+
+      result.config.backend = backend;
+
       const outPath = join(projectRoot, "shipkey.json");
       await writeFile(outPath, JSON.stringify(result.config, null, 2) + "\n");
       console.log(`\n  ✓ Written shipkey.json`);

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -24,6 +24,7 @@ function mergeConfigs(
   const merged: ShipkeyConfig = {
     project: existing.project,
     vault: existing.vault,
+    ...(existing.backend && { backend: existing.backend }),
   };
 
   // Merge providers: keep existing + add new from scan

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { resolve, join } from "path";
 import { readFile, writeFile } from "fs/promises";
+import { createInterface } from "readline";
 import { loadConfig, buildSecretRefMap } from "../config";
 import { scanProject, printScanSummary } from "../scanner/project";
 import type { ShipkeyConfig, TargetConfig } from "../config";
@@ -16,6 +17,19 @@ const TARGETS: Record<string, SyncTarget> = {
   github: new GitHubTarget(),
   cloudflare: new CloudflareTarget(),
 };
+
+async function promptBackend(): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(
+      "\n  Select a backend:\n    1) 1Password (default)\n    2) Bitwarden\n  Choice [1]: ",
+      (answer) => {
+        rl.close();
+        resolve(answer.trim());
+      }
+    );
+  });
+}
 
 function mergeConfigs(
   existing: ShipkeyConfig,
@@ -586,6 +600,12 @@ export const setupCommand = new Command("setup")
       config = mergeConfigs(existing, result.config);
     } else {
       config = result.config;
+    }
+
+    // Prompt for backend if not already set
+    if (!config.backend) {
+      const choice = await promptBackend();
+      config.backend = choice === "2" ? "bitwarden" : "1password";
     }
 
     // Write back (always, to capture new fields/permissions)


### PR DESCRIPTION
## Summary

- **Bug fix**: `mergeConfigs()` in the setup wizard silently dropped the `backend` field when merging existing config with scan results, causing Bitwarden users to have their backend reset to `1password` on every `shipkey setup` run
- **Feature**: `shipkey scan` and `shipkey setup` now prompt the user to select a backend (1Password or Bitwarden) before writing `shipkey.json` for the first time — existing configs with a backend already set are left untouched

## Test plan

- [ ] Run `shipkey scan` on a fresh project (no `shipkey.json`) — verify prompt appears and chosen backend is written to config
- [ ] Run `shipkey scan` on a project with `"backend": "bitwarden"` already set — verify no prompt and backend is preserved
- [ ] Run `shipkey setup` on a fresh project — verify prompt appears before the wizard opens
- [ ] Run `shipkey setup` on a project with `"backend": "bitwarden"` — verify no prompt and backend is preserved after setup completes
- [ ] Verify that `mergeConfigs` still correctly merges `providers` and `targets` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)