### PR TITLE
fix: preserve backend field when merging configs in setup

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -24,6 +24,7 @@ function mergeConfigs(
   const merged: ShipkeyConfig = {
     project: existing.project,
     vault: existing.vault,
+    ...(existing.backend && { backend: existing.backend }),
   };
 
   // Merge providers: keep existing + add new from scan


### PR DESCRIPTION
## Summary

- `mergeConfigs()` in `setup.ts` only carried over `project`, `vault`, `providers`, and `targets` — the `backend` field was silently dropped
- Users who set `"backend": "bitwarden"` in `shipkey.json` had it overwritten back to the `1password` default after every `shipkey setup` run
- Now preserves the existing `backend` value during config merge

## Test plan

- [ ] Set `"backend": "bitwarden"` in `shipkey.json`, run `shipkey setup`, verify `backend` field is preserved
- [ ] Run `shipkey setup` on a fresh project (no existing config), verify no `backend` field is added (keeps default behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)