### PR TITLE
fix: honor --vault in pull/list and resolve /api/sync env per-request

### DIFF
--- a/packages/core/src/backends/types.ts
+++ b/packages/core/src/backends/types.ts
@@ -17,7 +17,7 @@ export interface SecretBackend {
   checkStatus(): Promise<"not_installed" | "not_logged_in" | "ready">;
   read(ref: SecretRef): Promise<string>;
   write(entry: SecretEntry): Promise<void>;
-  list(project?: string, env?: string): Promise<SecretRef[]>;
+  list(project?: string, env?: string, vault?: string): Promise<SecretRef[]>;
   /** Return an inline reference (e.g. op:// URI) for use in .envrc, or null if the backend doesn't support inline refs */
   buildInlineRef?(ref: SecretRef): string | null;
 }

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -7,6 +7,7 @@ import { BULLET } from "../symbols";
 export const listCommand = new Command("list")
   .description("List keys stored in your password manager")
   .option("-e, --env <env>", "filter by environment")
+  .option("--vault <vault>", "Vault or folder name (defaults to shipkey.json vault)")
   .option("--all", "list all projects", false)
   .option("--project <name>", "project name (defaults to directory name)")
   .argument("[dir]", "project directory", ".")
@@ -16,9 +17,11 @@ export const listCommand = new Command("list")
     const env = opts.env;
 
     let backendName = "1password";
+    let vault: string | undefined = opts.vault;
     try {
       const config = await loadConfig(projectRoot);
       if (config.backend) backendName = config.backend;
+      if (!vault && config.vault) vault = config.vault;
     } catch {
       // No config file — use default backend
     }
@@ -31,7 +34,7 @@ export const listCommand = new Command("list")
       process.exit(1);
     }
 
-    const refs = await backend.list(project, env);
+    const refs = await backend.list(project, env, vault);
 
     if (refs.length === 0) {
       const scope = opts.all ? "any project" : `${project}${env ? `.${env}` : ""}`;

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -38,7 +38,7 @@ export const pullCommand = new Command("pull")
 
     console.log(`Pulling keys for ${project}.${env}...\n`);
 
-    const refs = await backend.list(project, env);
+    const refs = await backend.list(project, env, vault);
 
     if (refs.length === 0) {
       console.log(`No keys found for ${project}.${env} in vault ${vault}.`);

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -572,7 +572,8 @@ export function startServer(
         if (url.pathname === "/api/sync" && req.method === "POST") {
           const config = await reloadConfig();
           const body = await req.json();
-          return handleSync(config, env, body, backend);
+          const currentEnv = resolveEnv(url, body);
+          return handleSync(config, currentEnv, body, backend);
         }
 
         return json({ error: "Not found" }, 404);

--- a/test/commands/sync-env-e2e.test.ts
+++ b/test/commands/sync-env-e2e.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync, chmodSync } from "fs";
+import { join } from "path";
+
+// e2e: /api/sync must resolve the environment per-request (query param /
+// body), like /api/push and /api/store, instead of using the startup env.
+//
+// The server is run in a child process (test/helpers/sync-env-runner.ts)
+// with a stub `gh` binary on PATH, because Bun.spawn resolves binaries from
+// the process's initial environment.
+
+const TMP = join(import.meta.dir, "__sync_env_e2e_fixtures__");
+const STUB_DIR = join(TMP, "bin");
+const RUNNER = join(import.meta.dir, "..", "helpers", "sync-env-runner.ts");
+
+// Stub `gh` CLI: auth status and secret set always succeed.
+const GH_STUB = `#!/usr/bin/env bash
+exit 0
+`;
+
+type SyncObservation = {
+  data: { success: boolean; results: { synced: string[] }[] };
+  readEnvs: string[];
+};
+
+let results: {
+  queryParam: SyncObservation;
+  bodyEnv: SyncObservation;
+  fallback: SyncObservation;
+};
+
+beforeAll(async () => {
+  mkdirSync(STUB_DIR, { recursive: true });
+  const stubPath = join(STUB_DIR, "gh");
+  writeFileSync(stubPath, GH_STUB);
+  chmodSync(stubPath, 0o755);
+
+  const proc = Bun.spawn(["bun", RUNNER, join(TMP, "project")], {
+    env: { ...process.env, PATH: `${STUB_DIR}:${process.env.PATH}` },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    throw new Error(`sync-env-runner failed (${exitCode}): ${stderr}`);
+  }
+  results = JSON.parse(stdout);
+});
+
+afterAll(() => {
+  rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("e2e: /api/sync resolves env per-request", () => {
+  test("POST /api/sync?env=dev reads dev secrets, not startup env", () => {
+    const { data, readEnvs } = results.queryParam;
+    expect(data.success).toBe(true);
+    expect(data.results[0].synced).toContain("OPENAI_API_KEY");
+    expect(readEnvs).toContain("dev");
+    expect(readEnvs).not.toContain("prod");
+  });
+
+  test("POST /api/sync with env in body reads that env", () => {
+    const { data, readEnvs } = results.bodyEnv;
+    expect(data.success).toBe(true);
+    expect(data.results[0].synced).toContain("OPENAI_API_KEY");
+    expect(readEnvs).toContain("dev");
+  });
+
+  test("POST /api/sync without env falls back to startup env", () => {
+    const { data, readEnvs } = results.fallback;
+    // Key only exists in dev, so the prod (startup env) read fails
+    expect(data.success).toBe(false);
+    expect(readEnvs).toContain("prod");
+    expect(readEnvs).not.toContain("dev");
+  });
+});

--- a/test/commands/vault-e2e.test.ts
+++ b/test/commands/vault-e2e.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync, readFileSync, chmodSync, existsSync } from "fs";
+import { join } from "path";
+
+// e2e: run the real CLI with a stub `op` binary on PATH and assert which
+// vault is passed to the backend's `op item list` invocation.
+
+const TMP = join(import.meta.dir, "__vault_e2e_fixtures__");
+const STUB_DIR = join(TMP, "bin");
+const PROJECT_DIR = join(TMP, "myapp");
+const LOG_FILE = join(TMP, "op-calls.log");
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+
+const OP_STUB = `#!/usr/bin/env bash
+echo "$@" >> "$OP_STUB_LOG"
+case "$*" in
+  "account list --format=json") echo '[{"id":"stub-account"}]' ;;
+  *) echo '[]' ;;
+esac
+`;
+
+async function runCli(args: string[]): Promise<{ stdout: string; exitCode: number }> {
+  const proc = Bun.spawn(["bun", join(REPO_ROOT, "src", "index.ts"), ...args], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      PATH: `${STUB_DIR}:${process.env.PATH}`,
+      OP_STUB_LOG: LOG_FILE,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const exitCode = await proc.exited;
+  return { stdout, exitCode };
+}
+
+function opCalls(): string[] {
+  if (!existsSync(LOG_FILE)) return [];
+  return readFileSync(LOG_FILE, "utf-8").trim().split("\n");
+}
+
+beforeEach(() => {
+  mkdirSync(STUB_DIR, { recursive: true });
+  mkdirSync(PROJECT_DIR, { recursive: true });
+  const stubPath = join(STUB_DIR, "op");
+  writeFileSync(stubPath, OP_STUB);
+  chmodSync(stubPath, 0o755);
+});
+
+afterEach(() => {
+  rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("e2e: pull passes --vault through to the backend", () => {
+  test("pull --vault custom-vault queries that vault", async () => {
+    const { stdout, exitCode } = await runCli([
+      "pull",
+      "--vault",
+      "custom-vault",
+      PROJECT_DIR,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(opCalls()).toContain("item list --vault custom-vault --format json");
+    expect(stdout).toContain("custom-vault");
+  });
+
+  test("pull without --vault defaults to shipkey vault", async () => {
+    const { exitCode } = await runCli(["pull", PROJECT_DIR]);
+
+    expect(exitCode).toBe(0);
+    expect(opCalls()).toContain("item list --vault shipkey --format json");
+  });
+});
+
+describe("e2e: list resolves vault from flag or shipkey.json", () => {
+  test("list --vault custom-vault queries that vault", async () => {
+    const { exitCode } = await runCli(["list", "--vault", "custom-vault", PROJECT_DIR]);
+
+    expect(exitCode).toBe(0);
+    expect(opCalls()).toContain("item list --vault custom-vault --format json");
+  });
+
+  test("list uses vault from shipkey.json when no flag given", async () => {
+    writeFileSync(
+      join(PROJECT_DIR, "shipkey.json"),
+      JSON.stringify({ project: "myapp", vault: "team-secrets" }, null, 2)
+    );
+
+    const { exitCode } = await runCli(["list", PROJECT_DIR]);
+
+    expect(exitCode).toBe(0);
+    expect(opCalls()).toContain("item list --vault team-secrets --format json");
+  });
+
+  test("list --vault flag overrides shipkey.json vault", async () => {
+    writeFileSync(
+      join(PROJECT_DIR, "shipkey.json"),
+      JSON.stringify({ project: "myapp", vault: "team-secrets" }, null, 2)
+    );
+
+    const { exitCode } = await runCli(["list", "--vault", "override-vault", PROJECT_DIR]);
+
+    expect(exitCode).toBe(0);
+    expect(opCalls()).toContain("item list --vault override-vault --format json");
+  });
+});

--- a/test/helpers/mock-backend.ts
+++ b/test/helpers/mock-backend.ts
@@ -29,8 +29,8 @@ export class MockBackend implements SecretBackend {
     this.store.set(key, entry.value);
   }
 
-  async list(project?: string, env?: string) {
-    this.calls.push({ method: "list", args: [project, env] });
+  async list(project?: string, env?: string, vault?: string) {
+    this.calls.push({ method: "list", args: [project, env, vault] });
     const refs: SecretRef[] = [];
     for (const [key] of this.store) {
       // Parse "Provider/project-env/field"
@@ -43,7 +43,7 @@ export class MockBackend implements SecretBackend {
       const e = section.slice(dashIndex + 1);
       if (project && proj !== project) continue;
       if (env && e !== env) continue;
-      refs.push({ vault: "mock", provider, project: proj, env: e, field });
+      refs.push({ vault: vault ?? "mock", provider, project: proj, env: e, field });
     }
     return refs;
   }

--- a/test/helpers/sync-env-runner.ts
+++ b/test/helpers/sync-env-runner.ts
@@ -1,0 +1,63 @@
+// Helper for sync-env-e2e.test.ts. Runs in a child process whose PATH
+// contains a stub `gh` binary (Bun.spawn resolves binaries from the
+// process's initial environment, so the stub must be on PATH at startup).
+//
+// Starts the setup server with startup env "prod", seeds a key that only
+// exists in "dev", exercises /api/sync three ways, and prints the
+// observations as JSON.
+import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { startServer } from "../../src/commands/setup";
+import { MockBackend } from "./mock-backend";
+
+const TMP = process.argv[2];
+if (!TMP) {
+  console.error("usage: bun sync-env-runner.ts <tmp-dir>");
+  process.exit(1);
+}
+
+mkdirSync(TMP, { recursive: true });
+
+const config = {
+  project: "testapp",
+  vault: "shipkey",
+  providers: {
+    OpenAI: { fields: ["OPENAI_API_KEY"] },
+  },
+  targets: {
+    github: { "owner/repo": ["OPENAI_API_KEY"] },
+  },
+};
+const configPath = join(TMP, "shipkey.json");
+writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+const backend = new MockBackend();
+// Server starts with env="prod"; the key only exists in "dev".
+backend.seed("OpenAI", "testapp", "dev", "OPENAI_API_KEY", "sk-dev-123");
+
+const server = startServer(configPath, "prod", TMP, backend);
+const baseUrl = `http://localhost:${server.port}`;
+
+async function callSync(query: string, body: Record<string, unknown>) {
+  const res = await fetch(`${baseUrl}/api/sync${query}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  const readEnvs = backend.calls
+    .filter((c) => c.method === "read")
+    .map((c) => c.args[0].env);
+  backend.calls.length = 0;
+  return { data, readEnvs };
+}
+
+const results = {
+  queryParam: await callSync("?env=dev", { target: "github" }),
+  bodyEnv: await callSync("", { target: "github", env: "dev" }),
+  fallback: await callSync("", { target: "github" }),
+};
+
+server.stop();
+rmSync(TMP, { recursive: true, force: true });
+console.log(JSON.stringify(results));


### PR DESCRIPTION
## Summary

Fixes two confirmed bugs and one closely related inconsistency:

1. **`shipkey pull --vault <name>` was ignored.** `pull` accepted the flag but called `backend.list(project, env)` without it, so the default `shipkey` vault was always searched — directly contradicting the "No keys found ... in vault <name>" message. The vault is now passed through.

2. **`/api/sync` used the startup env instead of the request env.** The neighboring `/api/push` and `/api/store` endpoints resolve the environment per-request via `resolveEnv(url, body)`; `/api/sync` passed the hardcoded startup `env`, so syncing e.g. dev secrets from the setup UI while the server was started with `prod` read the wrong environment. It now resolves env the same way as its neighbors.

3. **`shipkey list` had no way to target a custom vault.** It now accepts a `--vault` flag (consistent with `pull`) and falls back to the `vault` configured in `shipkey.json` when the flag is omitted.

Supporting change: the `SecretBackend.list` interface gains the optional `vault` parameter that the 1Password and Bitwarden implementations already accepted (`list(project?, env?, vault = "shipkey")`).

## Tests

- `test/commands/vault-e2e.test.ts`: runs the real CLI with a stub `op` binary on PATH and asserts which `--vault` reaches `op item list` for `pull` (flag + default) and `list` (flag, config fallback, flag-overrides-config).
- `test/commands/sync-env-e2e.test.ts` (+ `test/helpers/sync-env-runner.ts`): runs the setup server in a child process with a stub `gh` binary and asserts `/api/sync` honors `?env=` and body `env`, falling back to the startup env otherwise.
- New tests fail against the unfixed code (6 failures) and pass with the fixes.
- Full suite: **154 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)